### PR TITLE
support thenables and remove async dependency

### DIFF
--- a/crap.js
+++ b/crap.js
@@ -21,8 +21,8 @@ var crap = module.exports = {
     }
     return result;
   },
-  resolve: function(type, name) {
-    return crap.root + '/' + type + '/' + name;
+  resolve: function(root, type, name) {
+    return root + '/' + type + '/' + name;
   },
   loaders: {
     file: function(crap_cfg, type, name, source) {
@@ -112,7 +112,7 @@ function load(type) {
   list.forEach(function(name) {
     var cfg = (crap_cfg[type] && crap_cfg[type][name]) || {};
 
-    var source = url.parse(cfg.source || crap.resolve(type, name));
+    var source = url.parse(cfg.source || crap.resolve(cfg.root || root, type, name));
     var protocol = (source.protocol || "file:").replace(/:$/,'');
     if(!cfg.root) cfg.root = root;
 

--- a/crap.js
+++ b/crap.js
@@ -84,21 +84,28 @@ function get_loader(protocol) {
 
 function load(type) {
   var list,crap_cfg,callback = arguments[arguments.length-1];
+  if(typeof callback!=='function') callback = undefined;
   var signature = Array.prototype.map.call(arguments, function(arg){ return Array.isArray(arg)? "array" : typeof arg }).join();
 
   switch(signature) {
+    case "string,string,object":
     case "string,string,object,function":
+    case "string,array,object":
     case "string,array,object,function":
       list = array(arguments[1]);
       crap_cfg = arguments[2];
       break;
+    case "string,array":
     case "string,array,function":
+    case "string,string":
     case "string,string,function":
       list = array(arguments[1]);
       break;
+    case "string,object":
     case "string,object,function":
       crap_cfg = arguments[1];
       break;
+    case "string":
     case "string,function":
       break;
     default:
@@ -124,12 +131,12 @@ function load(type) {
     tasks[name] = loader(cfg, type, name, source);
   });
 
-  parallel(tasks, function(err, result) {
+  return parallel(tasks, function(err, result) {
     if(debug.enabled) {
       if (err) debug("failed to load "+type+": "+list.join());
       else debug("...done loading "+type+": "+list.join());
     }
-    callback(err, result);
+    callback && callback(err, result);
   });
 }
 function array(list) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",
@@ -21,7 +21,6 @@
     "should": "^4.0.4"
   },
   "dependencies": {
-    "async": "^0.9.0",
     "debug": "^2.0.0"
   }
 }

--- a/parallel.js
+++ b/parallel.js
@@ -1,0 +1,34 @@
+
+//a parallel helper that works with callback style OR thenables
+module.exports = function parallel(tasks, done) {
+  var failed = false;
+  var results = {};
+  var num_complete = 0;
+  var keys = Object.keys(tasks);
+  if(!keys.length) return done(null, results);
+
+  keys.forEach(function (name) {
+    var worker = tasks[name];
+    var return_value = worker(callback.bind(name));
+    if(return_value && typeof return_value.then === "function")
+      return_value.then(success.bind(name), fail);
+  });
+
+  function callback(err, result) {
+    if(err) fail(err);
+    else success.call(this, result);
+  }
+  function success(result){
+    num_complete++;
+    var name = this; //cause we did .bind(name) above
+    results[name] = result;
+
+    if(num_complete===keys.length)
+      done(null, results);
+  }
+  function fail(err) {
+    if(failed) return;
+    failed = true;
+    done(err);
+  }
+};

--- a/parallel.js
+++ b/parallel.js
@@ -1,34 +1,49 @@
 
 //a parallel helper that works with callback style OR thenables
 module.exports = function parallel(tasks, done) {
-  var failed = false;
-  var results = {};
-  var num_complete = 0;
-  var keys = Object.keys(tasks);
-  if(!keys.length) return done(null, results);
 
-  keys.forEach(function (name) {
-    var worker = tasks[name];
-    var return_value = worker(callback.bind(name));
-    if(return_value && typeof return_value.then === "function")
-      return_value.then(success.bind(name), fail);
-  });
+  function executor(resolve, reject) {
+    var failed = false;
+    var results = {};
+    var num_complete = 0;
+    var keys = Object.keys(tasks);
+    if(!keys.length) {
+      if(resolve) resolve(results);
+      if(done) done(null, results);
+      return;
+    }
 
-  function callback(err, result) {
-    if(err) fail(err);
-    else success.call(this, result);
-  }
-  function success(result){
-    num_complete++;
-    var name = this; //cause we did .bind(name) above
-    results[name] = result;
+    keys.forEach(function (name) {
+      var worker = tasks[name];
+      var return_value = worker(callback.bind(name));
+      if(return_value && typeof return_value.then === "function")
+        return_value.then(success.bind(name), fail);
+    });
 
-    if(num_complete===keys.length)
-      done(null, results);
+    function callback(err, result) {
+      if(err) fail(err);
+      else success.call(this, result);
+    }
+    function success(result){
+      num_complete++;
+      var name = this; //cause we did .bind(name) above
+      results[name] = result;
+
+      if(num_complete===keys.length){
+        if(resolve) resolve(results);
+        if(done) done(null, results);
+      }
+    }
+    function fail(err) {
+      if(failed) return;
+      failed = true;
+      if(reject) reject(results);
+      if(done) done(err);
+    }
   }
-  function fail(err) {
-    if(failed) return;
-    failed = true;
-    done(err);
-  }
+
+  if(typeof Promise!=='undefined')
+    return new Promise(executor);
+
+  executor();
 };

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -4,7 +4,7 @@ var config = require("./crap.verbose.config.js");
 crap.load.apps(config, function(err, controllers) {
   console.log('done..');
   console.log(
-    JSON.stringify(controllers, null, 2)
+    err || JSON.stringify(controllers, null, 2)
   );
 });
 

--- a/test/load.test.js
+++ b/test/load.test.js
@@ -1,10 +1,69 @@
 var crap = require("../");
 var config = require("./crap.verbose.config.js");
+var should = require('should');
 
-crap.load.apps(config, function(err, controllers) {
-  console.log('done..');
-  console.log(
-    err || JSON.stringify(controllers, null, 2)
-  );
+var interfaces = {
+  "profile": {
+    "middleware": {
+      "auth": {
+        "controllers": {
+          "session": {
+            "providers": {
+              "session": {
+                "resources": {
+                  "session": {},
+                  "users": {}
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "controllers": {
+      "account": {
+        "providers": {
+          "account": {
+            "resources": {
+              "users": {},
+              "facebook": "facebook!!"
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+describe('crap load', function () {
+  if(typeof Promise!=='undefined') {
+    it('should support Promises', function (done) {
+      var result = crap.load.apps(config);
+      result.then(function(apps) {
+        should.exist(apps);
+        apps.should.eql(interfaces);
+        done();
+      })
+      .catch(done);
+    });
+  }
+  describe('without Promises', function () {
+    if(typeof Promise!=='undefined') {
+      var promise = Promise;
+      //BE SURE, everything works without Promises
+      before(function () { Promise = undefined; });
+      after(function () { Promise = promise; });
+    }
+
+    it('should load an entire chain of CRaP', function (done) {
+      Promise = undefined;
+      crap.load.apps(config, function(err, apps) {
+        should.not.exist(err);
+        should.exist(apps);
+        apps.should.eql(interfaces);
+        done();
+      });
+    });
+  });
 });
 

--- a/test/parallel.test.js
+++ b/test/parallel.test.js
@@ -1,0 +1,71 @@
+var parallel = require('../parallel.js');
+var should = require('should');
+
+
+function task(ms) {
+  return function (done) {
+    //negative causes failure
+    if(ms<0)
+      setTimeout(function () { done("boooo"); }, Math.abs(ms));
+    else
+      setTimeout(done, ms);
+  }
+}
+function tasks() {
+  var tasks = {};
+  for (var i = 0; i < arguments.length; i++)
+    tasks["t"+i] = task(arguments[i]);
+  return tasks;
+}
+
+function thenable(ms) {
+  return function (done) {
+    return {
+      then: function (resolve, reject) {
+        //negative causes failure
+        if(ms<0)
+          setTimeout(function () { reject("boooo"); }, Math.abs(ms));
+        else
+          setTimeout(resolve, ms);
+      }
+    }
+  }
+}
+function thenables() {
+  var tasks = {};
+  for (var i = 0; i < arguments.length; i++)
+    tasks["t"+i] = thenable(arguments[i]);
+  return tasks;
+}
+
+describe("parallel tests", function () {
+
+  it("should allow callback style (success)", function (done) {
+    parallel(tasks(10,500,20,50), function (err, results) {
+      (!err).should.be.true;
+      results.should.eql({ t0: undefined, t2: undefined, t3: undefined, t1: undefined });
+      done();
+    });
+  });
+  it("should allow callback style (failure)", function (done) {
+    parallel(tasks(10,500,-20,50), function (err, results) {
+      should(err).not.be.null;
+      (!results).should.be.true;
+      done();
+    });
+  });
+  it("should allow thenable style (success)", function (done) {
+    parallel(thenables(10,500,20,50), function (err, results) {
+      (!err).should.be.true;
+      results.should.eql({ t0: undefined, t2: undefined, t3: undefined, t1: undefined });
+      done();
+    });
+  });
+  it("should allow thenable style (failure)", function (done) {
+    parallel(thenables(10,500,-20,50), function (err, results) {
+      should(err).not.be.null;
+      (!results).should.be.true;
+      done();
+    });
+  });
+});

--- a/test/parallel.test.js
+++ b/test/parallel.test.js
@@ -8,7 +8,7 @@ function task(ms) {
     if(ms<0)
       setTimeout(function () { done("boooo"); }, Math.abs(ms));
     else
-      setTimeout(done, ms);
+      setTimeout(function () { done(null, "OK"); }, ms);
   }
 }
 function tasks() {
@@ -26,7 +26,7 @@ function thenable(ms) {
         if(ms<0)
           setTimeout(function () { reject("boooo"); }, Math.abs(ms));
         else
-          setTimeout(resolve, ms);
+          setTimeout(function () { resolve("OK"); }, ms);
       }
     }
   }
@@ -43,7 +43,7 @@ describe("parallel tests", function () {
   it("should allow callback style (success)", function (done) {
     parallel(tasks(10,500,20,50), function (err, results) {
       (!err).should.be.true;
-      results.should.eql({ t0: undefined, t2: undefined, t3: undefined, t1: undefined });
+      results.should.eql({ t0: 'OK', t1: 'OK', t2: 'OK', t3: 'OK' });
       done();
     });
   });
@@ -57,7 +57,7 @@ describe("parallel tests", function () {
   it("should allow thenable style (success)", function (done) {
     parallel(thenables(10,500,20,50), function (err, results) {
       (!err).should.be.true;
-      results.should.eql({ t0: undefined, t2: undefined, t3: undefined, t1: undefined });
+      results.should.eql({ t0: 'OK', t1: 'OK', t2: 'OK', t3: 'OK' });
       done();
     });
   });
@@ -68,4 +68,16 @@ describe("parallel tests", function () {
       done();
     });
   });
+
+  if(typeof Promise !== 'undefined') {
+    it("should return a Promise", function (done) {
+      var result = parallel(thenables(10, 500, 50));
+      result.should.be.instanceOf(Promise);
+      result.then(function (results) {
+        results.should.eql({ t0: 'OK', t1: 'OK', t2: 'OK' });
+        done();
+      })
+      .catch(done);
+    });
+  }
 });

--- a/test/providers/session.js
+++ b/test/providers/session.js
@@ -1,6 +1,12 @@
 
 module.exports = function auto(dependencies, callback){
   console.log("session provider initializing...");
-  callback(null, dependencies);
+  //return a thenable (in the future this would be a legit Promise)
+  return {
+    then: function(resolve, reject) {
+      //resolve(dependencies)
+      reject("booo!")
+    }
+  };
 };
 

--- a/test/providers/session.js
+++ b/test/providers/session.js
@@ -4,8 +4,8 @@ module.exports = function auto(dependencies, callback){
   //return a thenable (in the future this would be a legit Promise)
   return {
     then: function(resolve, reject) {
-      //resolve(dependencies)
-      reject("booo!")
+      resolve(dependencies)
+      //reject("booo!")
     }
   };
 };

--- a/test/resources/facebook.js
+++ b/test/resources/facebook.js
@@ -3,6 +3,14 @@ module.exports = function auto(dependencies, callback){
 //  var settings = this.config.settings;
 //  console.log(settings)
   console.log("facebook resource initializing...");
-  callback(null, dependencies);
+
+  //return a thenable (aka Promise)
+  return {
+    then: function(resolve, reject) {
+      resolve("facebook!!")
+    }
+  };
+  //return Promise.resolve("facebook!");
+  //return Promise.reject("facebook!");
 };
 


### PR DESCRIPTION
This is backwards compatible. Basically, if a CRAMP returns a thenable (Promise) it will use it instead of the callback argument

```javascript
module.exports = function auto(dependencies, callback){
  callback(null, { bar: 123 })
}
```
...or
```javascript
module.exports = function auto(dependencies){
  return Promise.resolve({ bar: 123 });
}
```

Although I'm not the BIGGEST fan of Promises (yet?)- they are a big part of ES6 now... which I'M LOVIN! 

