### PR TITLE
Only resolve the path if it starts with `/`, `./`, or `../`

### DIFF
--- a/crap.js
+++ b/crap.js
@@ -151,6 +151,7 @@ function array(list) {
 function bind_helpers(ctx){
   var l = load.bind(ctx);
   l.apps = load.bind(ctx, "apps");
+  l.apis = load.bind(ctx, "apis");
   l.middleware = load.bind(ctx, "middleware");
   l.controllers = load.bind(ctx, "controllers");
   l.providers = load.bind(ctx, "providers");

--- a/crap.js
+++ b/crap.js
@@ -26,7 +26,9 @@ var crap = module.exports = {
   },
   loaders: {
     file: function(crap_cfg, type, name, source) {
-      var pathname = path.resolve(crap_cfg.root, source.pathname);
+      var pathname = source.pathname;
+      if(/^\.?\.?\//.test(pathname))
+        pathname = path.resolve(crap_cfg.root, source.pathname);
       var query = source.query;
       var hash = source.hash && source.hash.substr(1);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "5.0.5",
+  "version": "5.0.6",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "crap",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "Ⓒontrollers Ⓡesources Ⓐnd ⓟroviders framework",
   "homepage": "https://github.com/tinder/crap",
   "main": "crap.js",

--- a/parallel.js
+++ b/parallel.js
@@ -25,6 +25,7 @@ module.exports = function parallel(tasks, done) {
       else success.call(this, result);
     }
     function success(result){
+      if(failed) return;
       num_complete++;
       var name = this; //cause we did .bind(name) above
       results[name] = result;

--- a/parallel.js
+++ b/parallel.js
@@ -38,7 +38,7 @@ module.exports = function parallel(tasks, done) {
     function fail(err) {
       if(failed) return;
       failed = true;
-      if(reject) reject(results);
+      if(reject) reject(err);
       if(done) done(err);
     }
   }

--- a/parallel.js
+++ b/parallel.js
@@ -30,16 +30,19 @@ module.exports = function parallel(tasks, done) {
       var name = this; //cause we did .bind(name) above
       results[name] = result;
 
-      if(num_complete===keys.length){
-        if(resolve) resolve(results);
-        if(done) done(null, results);
-      }
+      if(num_complete===keys.length)
+        process.nextTick(function(){
+          if (resolve) resolve(results);
+          if (done) done(null, results);
+        })
     }
     function fail(err) {
       if(failed) return;
       failed = true;
-      if(reject) reject(err);
-      if(done) done(err);
+      process.nextTick(function(){
+        if (reject) reject(err);
+        if (done) done(err);
+      })
     }
   }
 

--- a/parallel.js
+++ b/parallel.js
@@ -1,4 +1,4 @@
-
+var debug = require('debug')('crap:parallel');
 //a parallel helper that works with callback style OR thenables
 module.exports = function parallel(tasks, done) {
 
@@ -7,6 +7,7 @@ module.exports = function parallel(tasks, done) {
     var results = {};
     var num_complete = 0;
     var keys = Object.keys(tasks);
+    debug('runing tasks: %s', keys);
     if(!keys.length) {
       if(resolve) resolve(results);
       if(done) done(null, results);
@@ -15,28 +16,34 @@ module.exports = function parallel(tasks, done) {
 
     keys.forEach(function (name) {
       var worker = tasks[name];
-      var return_value = worker(callback.bind(name));
-      if(return_value && typeof return_value.then === "function")
+
+      function cb(err, result) {
+        if(thenable) return;//callback style not allowed if thenable used!
+        if (err) fail(err);
+        else success.call(name, result);
+      }
+      var return_value = worker(cb);
+      var thenable = return_value && typeof return_value.then === "function";
+      if(thenable)
         return_value.then(success.bind(name), fail);
     });
 
-    function callback(err, result) {
-      if(err) fail(err);
-      else success.call(this, result);
-    }
     function success(result){
+      var name = this; //cause we did .bind(name) above
+      debug('%s complete! %d/%d %s failed=%s', name, num_complete+1, keys.length, keys, failed);
       if(failed) return;
       num_complete++;
-      var name = this; //cause we did .bind(name) above
       results[name] = result;
 
-      if(num_complete===keys.length)
-        process.nextTick(function(){
+      if(num_complete===keys.length) {
+        process.nextTick(function () {
           if (resolve) resolve(results);
           if (done) done(null, results);
         })
+      }
     }
     function fail(err) {
+      debug('one fail! %s', keys);
       if(failed) return;
       failed = true;
       process.nextTick(function(){


### PR DESCRIPTION
This allows us to load modules instead of files
```javascript
var cfg = module.exports = {
  resources: {
    tokens: {
      settings:{ host:"tokens", port:6379 },
      source: 'crap-mocks?redis'
      //                  ^^^^^ db type 
    },
    users: {
      source: 'crap-mocks?mongo#users'
      //                        ^^^^^ collection name 
    }
  }
};
```